### PR TITLE
Bug: Fix incorrect country flag size on lower resolutions on the country page

### DIFF
--- a/src/views/CountryPage.vue
+++ b/src/views/CountryPage.vue
@@ -83,8 +83,11 @@ export default {
     }
 
     &__image {
-            width: 450px;
-            height: 450px;
+            width: 100%;
+            
+            @media (min-width: 1024px) {
+                width: 450px;
+        }
     }
 
     &__content {


### PR DESCRIPTION
# Story Title

[Bug: Fix the country flag size on the country page](https://github.com/mateuszdomagala/vue-rest-countries-api/issues/23)

## Changes made

* fix: add a media query for the country flag

## How does the solution address the problem

This PR will fix an issue with incorrect country flag size on the country page on lower resolutions

## Linked issues

Resolves #23 