### PR TITLE
API is not supported anymore

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -39,6 +39,8 @@ export default {
         border: 0;
         background-color: inherit;
         color: inherit;
+        width: 80%;
+        outline: 0;
     }
 
     @media (min-width: 660px) {

--- a/src/views/CountryPage.vue
+++ b/src/views/CountryPage.vue
@@ -48,12 +48,12 @@ export default {
         
         onMounted(async () => {
             try {
-                const countryResponse = await fetch(`https://restcountries.eu/rest/v2/name/${props.name}?fields=name;nativeName;population;region;subregion;capital;topLevelDomain;currencies;languages;borders;flag`)
+                const countryResponse = await fetch(`https://restcountries.com/v2/name/${props.name}?fields=name,nativeName,population,region,subregion,capital,topLevelDomain,currencies,languages,borders,flag`)
                 country.value = await countryResponse.json()
                 country.value = country.value[0]
-                alpha3Codes.value = country.value.borders.join(';')
+                alpha3Codes.value = country.value.borders.join(',')
 
-                const bordersResponse = await fetch(`https://restcountries.eu/rest/v2/alpha?codes=${alpha3Codes.value}`)
+                const bordersResponse = await fetch(`https://restcountries.com/v2/alpha?codes=${alpha3Codes.value}`)
                 borderCountries.value = await bordersResponse.json()
             } catch(e) {
                 error.value = e

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -32,7 +32,7 @@ export default {
 
     onMounted(async () => {
       try {
-        const res = await fetch('https://restcountries.eu/rest/v2/all?fields=name;capital;region;population;flag;alpha3Code')
+        const res = await fetch('https://restcountries.com/v2/all?fields=name,capital,region,population,flag,alpha3Code')
         countries.value = await res.json()
       } catch(e) {
         error.value = e


### PR DESCRIPTION
# Story Title

[API is not supported anymore](https://github.com/mateuszdomagala/vue-rest-countries-api/issues/26)

## Changes made

* fix: replace API with a new one

## How does the solution address the problem

This PR will replace [the original API](https://github.com/apilayer/restcountries), which [no longer works and is not supported](https://github.com/apilayer/restcountries/issues/253), with [a similar one](https://gitlab.com/amatos/rest-countries) based on a clone of the original.

## Linked issues

Resolves #26 